### PR TITLE
TASK: Switch defaults to new Neos Demo site package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Marcin Ryzycki marcin@m12.io
 ENV \
   T3APP_BUILD_REPO_URL="https://github.com/neos/neos-base-distribution.git" \
   T3APP_BUILD_BRANCH=master \
-  T3APP_NEOS_SITE_PACKAGE=TYPO3.NeosDemoTypo3Org
+  T3APP_NEOS_SITE_PACKAGE=Neos.Demo
 
 # Pre-install Neos CMS
 RUN . /build-typo3-app/pre-install-typo3-app.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ web:
     - db:db
   environment:
     T3APP_VHOST_NAMES: neos dev.neos behat.dev.neos
+    T3APP_NEOS_SITE_PACKAGE: Neos.Demo
 
 #dev:
 #  image: million12/php-app-ssh


### PR DESCRIPTION
Hi there!

This is just a little adjustment, since `TYPO3.NeosDemoTypo3Org` was replaced with `Neos.Demo` as the site package key and `docker-compose up` was failing in the current setup due to this.
